### PR TITLE
Bright studio scene: lighting, tablet look, and room polish

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -34,6 +34,7 @@
   let showCheckerboard = $state(false);
   let axonometric      = $state(false);
   let penDisplayMode   = $state(false);
+  let darkTablet       = $state(false);
 
   // ── Pointer-tracking state ─────────────────────────────────────────────────
   let cursorOffsetX       = $state(0);
@@ -207,6 +208,7 @@
   function onShowCheckerboard() { sim.setTabletCheckerboardVisible(showCheckerboard); }
   function onAxonometric()      { sim.setAxonometricView(axonometric); }
   function onPenDisplayMode()   { sim.setPenDisplayMode(penDisplayMode); }
+  function onDarkTablet()       { sim.setDarkTablet(darkTablet); }
 
   function allAnnotationsOn() {
     showAltitude = showAzimuth = showTiltX = showTiltY = showBarrel = showAxis = showCursor = showPenShadow = true;
@@ -410,6 +412,7 @@
   bind:barrelRotation
   bind:axonometric
   bind:penDisplayMode
+  bind:darkTablet
   {azimuthDisabled}
   {tiltXDisplay}
   {tiltYDisplay}
@@ -421,6 +424,7 @@
   {onBarrel}
   {onAxonometric}
   {onPenDisplayMode}
+  {onDarkTablet}
   bind:showCameraInfo
   {cameraPos}
   {cameraTarget}

--- a/src/lib/LeftPanel.svelte
+++ b/src/lib/LeftPanel.svelte
@@ -10,6 +10,7 @@
     barrelRotation = $bindable(),
     axonometric    = $bindable(),
     penDisplayMode = $bindable(),
+    darkTablet     = $bindable(),
     azimuthDisabled,
     tiltXDisplay,
     tiltYDisplay,
@@ -21,6 +22,7 @@
     onBarrel,
     onAxonometric,
     onPenDisplayMode,
+    onDarkTablet,
     showCameraInfo = $bindable(),
     cameraPos,
     cameraTarget,
@@ -73,6 +75,12 @@
   </div>
 
   <div class="checkbox-grid">
+    <div class="control-group">
+      <label style="display:flex;align-items:center;gap:8px;">
+        <input type="checkbox" bind:checked={darkTablet} onchange={onDarkTablet} style="width:auto;margin:0;">
+        <span>Dark tablet</span>
+      </label>
+    </div>
     <div class="control-group">
       <label style="display:flex;align-items:center;gap:8px;">
         <input type="checkbox" bind:checked={showCameraInfo} style="width:auto;margin:0;">

--- a/src/lib/sim/Pen3DSim.js
+++ b/src/lib/sim/Pen3DSim.js
@@ -74,7 +74,6 @@ export class Pen3DSim {
         this.initPen();
         this.initAnnotations();
         this.initAxisMarkers();
-        this.initComposer();
 
         // Start render loop
         this.animate();
@@ -90,7 +89,7 @@ export class Pen3DSim {
         const loop = () => {
             requestAnimationFrame(loop);
             this.controls.update();
-            this.renderFrame();
+            this.renderer.render(this.scene, this.camera);
             if (this.onCameraUpdate) {
                 const pos = this.camera.position;
                 const target = this.controls.target;
@@ -339,7 +338,6 @@ export class Pen3DSim {
         }
         this.controls.object = this.camera;
         this.controls.update();
-        this.syncComposerCamera();
     }
 
     // ── Cursor orientation ────────────────────────────────────────────────────
@@ -367,10 +365,9 @@ export class Pen3DSim {
 
         this.renderer.setPixelRatio(EXPORT.supersample);
         this.renderer.setSize(width, height);
-        if (this.composer) this.composer.setSize(width, height);
         this.perspectiveCamera.aspect = width / height;
         this.perspectiveCamera.updateProjectionMatrix();
-        this.renderFrame();
+        this.renderer.render(this.scene, this.camera);
 
         const canvas = document.createElement('canvas');
         canvas.width = width;
@@ -385,7 +382,6 @@ export class Pen3DSim {
 
         this.renderer.setPixelRatio(origPixelRatio);
         this.renderer.setSize(origWidth, origHeight);
-        if (this.composer) this.composer.setSize(origWidth, origHeight);
         this.perspectiveCamera.aspect = origWidth / origHeight;
         this.perspectiveCamera.updateProjectionMatrix();
     }
@@ -398,9 +394,6 @@ export class Pen3DSim {
         this.orthographicCamera.right  =  this.orthoSize * aspect;
         this.orthographicCamera.updateProjectionMatrix();
         this.renderer.setSize(this.viewer.clientWidth, this.viewer.clientHeight);
-        if (this.composer) {
-            this.composer.setSize(this.viewer.clientWidth, this.viewer.clientHeight);
-        }
     }
 
     // ── Animation helpers ─────────────────────────────────────────────────────

--- a/src/lib/sim/Pen3DSim.js
+++ b/src/lib/sim/Pen3DSim.js
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { TexturesFactory } from './textures.js';
 import {
     TABLET, DEFAULT_PEN, DEMO_POSE, PEN_RANGES, POINTER_DEFAULTS,
-    ANNOTATION, CURSOR, EXPORT, ANIMATION, clampValue,
+    ANNOTATION, CURSOR, EXPORT, ANIMATION, SCENE, clampValue,
 } from './config.js';
 
 // Pen3DSim.js — Class skeleton: constructor, animate loop, and public API
@@ -256,21 +256,48 @@ export class Pen3DSim {
 
     setTabletCheckerboardVisible(visible) {
         if (!this.tabletMaterial) return;
+        this.tabletCheckerboardVisible = visible;
         if (visible) {
-            if (!this.tabletCheckerboardTexture) {
-                this.tabletCheckerboardTexture = TexturesFactory.createTabletCheckerboardTexture(this.tabletWidth, this.tabletDepth);
+            const dark = this.darkTablet;
+            const c1 = dark ? '#5c4a6e' : '#e4d8f0';
+            const c2 = dark ? '#3a2c48' : '#c8b4dc';
+            // Rebuild so light/dark mode always matches
+            if (this.tabletCheckerboardTexture) {
+                this.tabletCheckerboardTexture.dispose();
             }
+            this.tabletCheckerboardTexture = TexturesFactory.createTabletCheckerboardTexture(
+                this.tabletWidth, this.tabletDepth, c1, c2
+            );
             this.tabletMaterial.map = this.tabletCheckerboardTexture;
-            this.tabletMaterial.roughness = 0.7;
-            this.tabletMaterial.metalness = 0.2;
+            this.tabletMaterial.roughness = 0.92;
+            this.tabletMaterial.metalness = 0.0;
             this.tabletMaterial.color.setHex(0xffffff);
         } else {
             this.tabletMaterial.map = null;
             this.tabletMaterial.color.setHex(this.tabletBaseColor);
-            this.tabletMaterial.roughness = 0.7;
-            this.tabletMaterial.metalness = 0.2;
+            this.tabletMaterial.roughness = 0.92;
+            this.tabletMaterial.metalness = 0.0;
         }
         this.tabletMaterial.needsUpdate = true;
+    }
+
+    /**
+     * Switch tablet body between light lavender and a much darker lavender.
+     * @param {boolean} dark
+     */
+    setDarkTablet(dark) {
+        this.darkTablet = !!dark;
+        this.tabletBaseColor = dark ? SCENE.tabletDark : SCENE.tablet;
+        if (this.gridMaterial) {
+            this.gridMaterial.color.setHex(dark ? SCENE.gridDark : SCENE.grid);
+            this.gridMaterial.opacity = dark ? 0.4 : 0.55;
+        }
+        if (this.tabletCheckerboardVisible) {
+            this.setTabletCheckerboardVisible(true);
+        } else if (this.tabletMaterial) {
+            this.tabletMaterial.color.setHex(this.tabletBaseColor);
+            this.tabletMaterial.needsUpdate = true;
+        }
     }
 
     setPenDisplayMode(enabled) {

--- a/src/lib/sim/Pen3DSim.js
+++ b/src/lib/sim/Pen3DSim.js
@@ -74,6 +74,7 @@ export class Pen3DSim {
         this.initPen();
         this.initAnnotations();
         this.initAxisMarkers();
+        this.initComposer();
 
         // Start render loop
         this.animate();
@@ -89,7 +90,7 @@ export class Pen3DSim {
         const loop = () => {
             requestAnimationFrame(loop);
             this.controls.update();
-            this.renderer.render(this.scene, this.camera);
+            this.renderFrame();
             if (this.onCameraUpdate) {
                 const pos = this.camera.position;
                 const target = this.controls.target;
@@ -338,6 +339,7 @@ export class Pen3DSim {
         }
         this.controls.object = this.camera;
         this.controls.update();
+        this.syncComposerCamera();
     }
 
     // ── Cursor orientation ────────────────────────────────────────────────────
@@ -365,9 +367,10 @@ export class Pen3DSim {
 
         this.renderer.setPixelRatio(EXPORT.supersample);
         this.renderer.setSize(width, height);
+        if (this.composer) this.composer.setSize(width, height);
         this.perspectiveCamera.aspect = width / height;
         this.perspectiveCamera.updateProjectionMatrix();
-        this.renderer.render(this.scene, this.camera);
+        this.renderFrame();
 
         const canvas = document.createElement('canvas');
         canvas.width = width;
@@ -382,6 +385,7 @@ export class Pen3DSim {
 
         this.renderer.setPixelRatio(origPixelRatio);
         this.renderer.setSize(origWidth, origHeight);
+        if (this.composer) this.composer.setSize(origWidth, origHeight);
         this.perspectiveCamera.aspect = origWidth / origHeight;
         this.perspectiveCamera.updateProjectionMatrix();
     }
@@ -394,6 +398,9 @@ export class Pen3DSim {
         this.orthographicCamera.right  =  this.orthoSize * aspect;
         this.orthographicCamera.updateProjectionMatrix();
         this.renderer.setSize(this.viewer.clientWidth, this.viewer.clientHeight);
+        if (this.composer) {
+            this.composer.setSize(this.viewer.clientWidth, this.viewer.clientHeight);
+        }
     }
 
     // ── Animation helpers ─────────────────────────────────────────────────────

--- a/src/lib/sim/config.js
+++ b/src/lib/sim/config.js
@@ -10,6 +10,19 @@ export const TABLET = {
     bodyMargin: 1.5,
 };
 
+/** Bright studio palette for the 3D environment (not the control panel). */
+export const SCENE = {
+    background: 0xf0eee8,
+    wall: 0xf7f6f2,
+    floor: 0xe8e4dc,
+    desk: 0xd4b896,
+    deskGrainDark: 0xc9a87c,
+    tablet: 0xf3d4d8,
+    tabletBase: 0xf3d4d8,
+    grid: 0x9a6a75,
+    monitorBezel: 0x2a2a2e,
+};
+
 export const DEFAULT_PEN = {
     distance: 0,
     tiltAltitude: 0,

--- a/src/lib/sim/config.js
+++ b/src/lib/sim/config.js
@@ -6,8 +6,8 @@
 export const TABLET = {
     width: 16,
     depth: 9,
-    thickness: 0.35,
-    bodyMargin: 1.5,
+    thickness: 0.22,
+    bodyMargin: 0.45,
 };
 
 /** Bright studio palette for the 3D environment (not the control panel). */
@@ -17,9 +17,14 @@ export const SCENE = {
     floor: 0xe8e4dc,
     desk: 0xd4b896,
     deskGrainDark: 0xc9a87c,
-    tablet: 0xf3d4d8,
-    tabletBase: 0xf3d4d8,
-    grid: 0x9a6a75,
+    tablet: 0xd4c4e4,
+    tabletBase: 0xd4c4e4,
+    /** Dark lavender variant of the tablet body */
+    tabletDark: 0x4a3a58,
+    /** Digitizer grid on light tablet — deeper lavender for readable contrast */
+    grid: 0x8f6fa8,
+    /** Digitizer grid on dark tablet — slightly lighter lavender */
+    gridDark: 0x6e5a82,
     monitorBezel: 0x2a2a2e,
 };
 

--- a/src/lib/sim/config.js
+++ b/src/lib/sim/config.js
@@ -14,7 +14,9 @@ export const TABLET = {
 export const SCENE = {
     background: 0xf0eee8,
     wall: 0xf7f6f2,
-    floor: 0xe8e4dc,
+    floor: 0xd8d2c6,
+    /** Brighter than wall paint — soft trim at the floor line */
+    baseboard: 0xffffff,
     desk: 0xd4b896,
     deskGrainDark: 0xc9a87c,
     tablet: 0xd4c4e4,

--- a/src/lib/sim/materials.js
+++ b/src/lib/sim/materials.js
@@ -90,9 +90,9 @@ export class MaterialsFactory {
         return new THREE.MeshBasicMaterial({ map: texture });
     }
 
-    // Tablet material — pale pink
+    // Tablet material — soft lavender, matte low-poly slab
     static createTabletMaterial() {
-        return this.createStandardMaterial(SCENE.tablet, 0.55, 0.08);
+        return this.createStandardMaterial(SCENE.tablet, 0.92, 0.0);
     }
 
     // Tablet wireframe material
@@ -100,9 +100,13 @@ export class MaterialsFactory {
         return this.createLineBasicMaterial(0x808080, 1);
     }
 
-    // Grid material — darker for contrast on lighter tablet
+    // Grid material — soft contrast against the tablet body
     static createGridMaterial() {
-        return this.createLineBasicMaterial(SCENE.grid, 1);
+        return new THREE.LineBasicMaterial({
+            color: SCENE.grid,
+            transparent: true,
+            opacity: 0.55,
+        });
     }
 
     // Pen tip/barrel material (with texture)

--- a/src/lib/sim/materials.js
+++ b/src/lib/sim/materials.js
@@ -74,6 +74,14 @@ export class MaterialsFactory {
         return material;
     }
 
+    // Baseboard — brighter matte trim along the floor line
+    static createBaseboardMaterial() {
+        const material = this.createStandardMaterial(SCENE.baseboard, 0.9, 0.0);
+        material.emissive = new THREE.Color(0xffffff);
+        material.emissiveIntensity = 0.12;
+        return material;
+    }
+
     // Floor material — pale warm gray
     static createFloorMaterial() {
         return this.createStandardMaterial(SCENE.floor, 0.92, 0.0);

--- a/src/lib/sim/materials.js
+++ b/src/lib/sim/materials.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { SCENE } from './config.js';
 
 // Materials Factory - Creates all materials used in Pen3DSim
 
@@ -52,14 +53,35 @@ export class MaterialsFactory {
 
     // Specific material creators for common use cases
 
-    // Desk material
-    static createDeskMaterial() {
-        return this.createStandardMaterial(0x7B4A2D, 0.85, 0.05);
+    // Desk material — light maple; optional wood-grain map for the top
+    static createDeskMaterial(map = null) {
+        // When a grain map is provided it already carries the wood color — use white
+        // as the tint so the texture is not darkened by multiplication.
+        const color = map ? 0xffffff : SCENE.desk;
+        return this.createStandardMaterial(color, 0.82, 0.02, map);
+    }
+
+    // Desk leg material — solid light wood (no grain map)
+    static createDeskLegMaterial() {
+        return this.createStandardMaterial(SCENE.deskGrainDark, 0.85, 0.02);
+    }
+
+    // Wall material — matte white studio (slight emissive so walls stay bright)
+    static createWallMaterial() {
+        const material = this.createStandardMaterial(0xffffff, 0.98, 0.0);
+        material.emissive = new THREE.Color(0xf5f4f0);
+        material.emissiveIntensity = 0.22;
+        return material;
+    }
+
+    // Floor material — pale warm gray
+    static createFloorMaterial() {
+        return this.createStandardMaterial(SCENE.floor, 0.92, 0.0);
     }
 
     // Monitor bezel / stand material
     static createMonitorBezelMaterial() {
-        return this.createStandardMaterial(0x1e1e1e, 0.8, 0.1);
+        return this.createStandardMaterial(SCENE.monitorBezel, 0.75, 0.15);
     }
 
     // Monitor screen material — self-lit (MeshBasicMaterial) so the desktop
@@ -68,9 +90,9 @@ export class MaterialsFactory {
         return new THREE.MeshBasicMaterial({ map: texture });
     }
 
-    // Tablet material
+    // Tablet material — pale pink
     static createTabletMaterial() {
-        return this.createStandardMaterial(0x505050, 0.7, 0.2);
+        return this.createStandardMaterial(SCENE.tablet, 0.55, 0.08);
     }
 
     // Tablet wireframe material
@@ -78,9 +100,9 @@ export class MaterialsFactory {
         return this.createLineBasicMaterial(0x808080, 1);
     }
 
-    // Grid material
+    // Grid material — darker for contrast on lighter tablet
     static createGridMaterial() {
-        return this.createLineBasicMaterial(0x5a5a5a, 1);
+        return this.createLineBasicMaterial(SCENE.grid, 1);
     }
 
     // Pen tip/barrel material (with texture)

--- a/src/lib/sim/pen-scene.js
+++ b/src/lib/sim/pen-scene.js
@@ -1,5 +1,9 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
+import { GTAOPass } from 'three/examples/jsm/postprocessing/GTAOPass.js';
+import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
 import { Pen3DSim } from './Pen3DSim.js';
 import { SCENE } from './config.js';
 
@@ -44,12 +48,77 @@ Object.assign(Pen3DSim.prototype, {
     },
 
     initRenderer() {
-        this.renderer = new THREE.WebGLRenderer({ antialias: true, preserveDrawingBuffer: true, logarithmicDepthBuffer: true });
+        // No logarithmic depth — GTAO reconstructs positions from a linear depth buffer
+        this.renderer = new THREE.WebGLRenderer({ antialias: true, preserveDrawingBuffer: true });
         this.renderer.setSize(this.viewer.clientWidth, this.viewer.clientHeight);
         this.renderer.shadowMap.enabled = true;
         this.renderer.shadowMap.type = THREE.PCFShadowMap;
         this.renderer.outputColorSpace = THREE.SRGBColorSpace;
         this.viewer.appendChild(this.renderer.domElement);
+    },
+
+    /** Ground-truth AO for contact shading around the pen, tablet, and desk. */
+    initComposer() {
+        const width = this.viewer.clientWidth;
+        const height = this.viewer.clientHeight;
+
+        this.composer = new EffectComposer(this.renderer);
+
+        this.renderPass = new RenderPass(this.scene, this.camera);
+        this.composer.addPass(this.renderPass);
+
+        this.gtaoPass = new GTAOPass(this.scene, this.camera, width, height);
+        this.gtaoPass.output = GTAOPass.OUTPUT.Default;
+        // World units are inches; keep AO local to creases / contact edges
+        this.gtaoPass.updateGtaoMaterial({
+            radius: 2.5,
+            distanceExponent: 1.5,
+            thickness: 1.5,
+            scale: 1.15,
+            samples: 16,
+            distanceFallOff: 1.0,
+            screenSpaceRadius: false,
+        });
+        this.gtaoPass.updatePdMaterial({
+            lumaPhi: 10,
+            depthPhi: 2,
+            normalPhi: 3,
+            radius: 8,
+            radiusExponent: 1.5,
+            rings: 2,
+            samples: 16,
+        });
+        this.gtaoPass.blendIntensity = 0.7;
+        this.composer.addPass(this.gtaoPass);
+
+        this.composer.addPass(new OutputPass());
+
+        const clipBox = new THREE.Box3().setFromObject(this.scene);
+        if (!clipBox.isEmpty()) {
+            this.gtaoPass.setSceneClipBox(clipBox);
+        }
+    },
+
+    /** Keep AO / render passes pointed at the active camera (perspective ↔ ortho). */
+    syncComposerCamera() {
+        if (!this.composer || !this.gtaoPass || !this.renderPass) return;
+        this.renderPass.camera = this.camera;
+        this.gtaoPass.camera = this.camera;
+        const isPersp = this.camera.isPerspectiveCamera ? 1 : 0;
+        if (this.gtaoPass.gtaoMaterial.defines.PERSPECTIVE_CAMERA !== isPersp) {
+            this.gtaoPass.gtaoMaterial.defines.PERSPECTIVE_CAMERA = isPersp;
+            this.gtaoPass.gtaoMaterial.needsUpdate = true;
+        }
+        this.gtaoPass.gtaoMaterial.uniforms.cameraNear.value = this.camera.near;
+        this.gtaoPass.gtaoMaterial.uniforms.cameraFar.value = this.camera.far;
+    },
+
+    renderFrame() {
+        if (this.composer) {
+            this.composer.render();
+        } else {
+            this.renderer.render(this.scene, this.camera);
+        }
     },
 
     initControls() {
@@ -209,6 +278,7 @@ Object.assign(Pen3DSim.prototype, {
             this.camera.updateProjectionMatrix();
 
             this.controls.update();
+            this.syncComposerCamera();
             return true;
         } catch (error) {
             throw new Error(`Error applying camera settings: ${error.message}`);

--- a/src/lib/sim/pen-scene.js
+++ b/src/lib/sim/pen-scene.js
@@ -47,7 +47,7 @@ Object.assign(Pen3DSim.prototype, {
         this.renderer = new THREE.WebGLRenderer({ antialias: true, preserveDrawingBuffer: true, logarithmicDepthBuffer: true });
         this.renderer.setSize(this.viewer.clientWidth, this.viewer.clientHeight);
         this.renderer.shadowMap.enabled = true;
-        this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+        this.renderer.shadowMap.type = THREE.PCFShadowMap;
         this.renderer.outputColorSpace = THREE.SRGBColorSpace;
         this.viewer.appendChild(this.renderer.domElement);
     },
@@ -72,8 +72,10 @@ Object.assign(Pen3DSim.prototype, {
         const directionalLight = new THREE.DirectionalLight(0xfff5eb, 0.75);
         directionalLight.position.set(8, 28, 12);
         directionalLight.castShadow = true;
-        directionalLight.shadow.mapSize.width = 2048;
-        directionalLight.shadow.mapSize.height = 2048;
+        // Higher res + PCF (not soft) keeps the pen shadow sharper without
+        // clipping the rest of the room’s shadow coverage.
+        directionalLight.shadow.mapSize.width = 4096;
+        directionalLight.shadow.mapSize.height = 4096;
         directionalLight.shadow.camera.left = -50;
         directionalLight.shadow.camera.right = 50;
         directionalLight.shadow.camera.top = 40;

--- a/src/lib/sim/pen-scene.js
+++ b/src/lib/sim/pen-scene.js
@@ -1,9 +1,5 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
-import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
-import { GTAOPass } from 'three/examples/jsm/postprocessing/GTAOPass.js';
-import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
 import { Pen3DSim } from './Pen3DSim.js';
 import { SCENE } from './config.js';
 
@@ -48,77 +44,12 @@ Object.assign(Pen3DSim.prototype, {
     },
 
     initRenderer() {
-        // No logarithmic depth — GTAO reconstructs positions from a linear depth buffer
-        this.renderer = new THREE.WebGLRenderer({ antialias: true, preserveDrawingBuffer: true });
+        this.renderer = new THREE.WebGLRenderer({ antialias: true, preserveDrawingBuffer: true, logarithmicDepthBuffer: true });
         this.renderer.setSize(this.viewer.clientWidth, this.viewer.clientHeight);
         this.renderer.shadowMap.enabled = true;
         this.renderer.shadowMap.type = THREE.PCFShadowMap;
         this.renderer.outputColorSpace = THREE.SRGBColorSpace;
         this.viewer.appendChild(this.renderer.domElement);
-    },
-
-    /** Ground-truth AO for contact shading around the pen, tablet, and desk. */
-    initComposer() {
-        const width = this.viewer.clientWidth;
-        const height = this.viewer.clientHeight;
-
-        this.composer = new EffectComposer(this.renderer);
-
-        this.renderPass = new RenderPass(this.scene, this.camera);
-        this.composer.addPass(this.renderPass);
-
-        this.gtaoPass = new GTAOPass(this.scene, this.camera, width, height);
-        this.gtaoPass.output = GTAOPass.OUTPUT.Default;
-        // World units are inches; keep AO local to creases / contact edges
-        this.gtaoPass.updateGtaoMaterial({
-            radius: 2.5,
-            distanceExponent: 1.5,
-            thickness: 1.5,
-            scale: 1.15,
-            samples: 16,
-            distanceFallOff: 1.0,
-            screenSpaceRadius: false,
-        });
-        this.gtaoPass.updatePdMaterial({
-            lumaPhi: 10,
-            depthPhi: 2,
-            normalPhi: 3,
-            radius: 8,
-            radiusExponent: 1.5,
-            rings: 2,
-            samples: 16,
-        });
-        this.gtaoPass.blendIntensity = 0.7;
-        this.composer.addPass(this.gtaoPass);
-
-        this.composer.addPass(new OutputPass());
-
-        const clipBox = new THREE.Box3().setFromObject(this.scene);
-        if (!clipBox.isEmpty()) {
-            this.gtaoPass.setSceneClipBox(clipBox);
-        }
-    },
-
-    /** Keep AO / render passes pointed at the active camera (perspective ↔ ortho). */
-    syncComposerCamera() {
-        if (!this.composer || !this.gtaoPass || !this.renderPass) return;
-        this.renderPass.camera = this.camera;
-        this.gtaoPass.camera = this.camera;
-        const isPersp = this.camera.isPerspectiveCamera ? 1 : 0;
-        if (this.gtaoPass.gtaoMaterial.defines.PERSPECTIVE_CAMERA !== isPersp) {
-            this.gtaoPass.gtaoMaterial.defines.PERSPECTIVE_CAMERA = isPersp;
-            this.gtaoPass.gtaoMaterial.needsUpdate = true;
-        }
-        this.gtaoPass.gtaoMaterial.uniforms.cameraNear.value = this.camera.near;
-        this.gtaoPass.gtaoMaterial.uniforms.cameraFar.value = this.camera.far;
-    },
-
-    renderFrame() {
-        if (this.composer) {
-            this.composer.render();
-        } else {
-            this.renderer.render(this.scene, this.camera);
-        }
     },
 
     initControls() {
@@ -278,7 +209,6 @@ Object.assign(Pen3DSim.prototype, {
             this.camera.updateProjectionMatrix();
 
             this.controls.update();
-            this.syncComposerCamera();
             return true;
         } catch (error) {
             throw new Error(`Error applying camera settings: ${error.message}`);

--- a/src/lib/sim/pen-scene.js
+++ b/src/lib/sim/pen-scene.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { Pen3DSim } from './Pen3DSim.js';
+import { SCENE } from './config.js';
 
 // pen-scene.js — Scene, renderer, cameras, lighting, and camera settings
 // Extends Pen3DSim.prototype (must be loaded after Pen3DSim.js)
@@ -9,7 +10,7 @@ Object.assign(Pen3DSim.prototype, {
 
     initScene() {
         this.scene = new THREE.Scene();
-        this.scene.background = new THREE.Color(0x1a1a1a);
+        this.scene.background = new THREE.Color(SCENE.background);
     },
 
     initCameras() {
@@ -47,6 +48,7 @@ Object.assign(Pen3DSim.prototype, {
         this.renderer.setSize(this.viewer.clientWidth, this.viewer.clientHeight);
         this.renderer.shadowMap.enabled = true;
         this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+        this.renderer.outputColorSpace = THREE.SRGBColorSpace;
         this.viewer.appendChild(this.renderer.domElement);
     },
 
@@ -62,24 +64,37 @@ Object.assign(Pen3DSim.prototype, {
     },
 
     initLighting() {
-        const ambientLight = new THREE.AmbientLight(0xffffff, 0.5);
+        // Soft ambient so light wood and white walls stay bright
+        const ambientLight = new THREE.AmbientLight(0xffffff, 0.88);
         this.scene.add(ambientLight);
 
-        const directionalLight = new THREE.DirectionalLight(0xffffff, 0.8);
-        directionalLight.position.set(0, 20, 0);
+        // Warm key from above-front
+        const directionalLight = new THREE.DirectionalLight(0xfff5eb, 0.75);
+        directionalLight.position.set(8, 28, 12);
         directionalLight.castShadow = true;
         directionalLight.shadow.mapSize.width = 2048;
         directionalLight.shadow.mapSize.height = 2048;
-        directionalLight.shadow.camera.left = -40;
-        directionalLight.shadow.camera.right = 40;
-        directionalLight.shadow.camera.top = 30;
-        directionalLight.shadow.camera.bottom = -30;
+        directionalLight.shadow.camera.left = -50;
+        directionalLight.shadow.camera.right = 50;
+        directionalLight.shadow.camera.top = 40;
+        directionalLight.shadow.camera.bottom = -40;
         directionalLight.shadow.camera.near = 0.1;
-        directionalLight.shadow.camera.far = 60;
+        directionalLight.shadow.camera.far = 100;
+        directionalLight.shadow.bias = -0.0002;
         this.scene.add(directionalLight);
 
-        const pointLight = new THREE.PointLight(0xffffff, 0.3);
-        pointLight.position.set(-10, 10, -10);
+        // Cool fill from the front so the desk isn’t flat
+        const fillLight = new THREE.DirectionalLight(0xe8f0ff, 0.45);
+        fillLight.position.set(-6, 12, 22);
+        this.scene.add(fillLight);
+
+        // Soft bounce from behind to lift white walls
+        const wallFill = new THREE.DirectionalLight(0xffffff, 0.3);
+        wallFill.position.set(0, 20, -30);
+        this.scene.add(wallFill);
+
+        const pointLight = new THREE.PointLight(0xffffff, 0.2);
+        pointLight.position.set(-12, 14, -8);
         this.scene.add(pointLight);
     },
 

--- a/src/lib/sim/pen-tablet.js
+++ b/src/lib/sim/pen-tablet.js
@@ -85,7 +85,7 @@ Object.assign(Pen3DSim.prototype, {
         const floorY = -29;
         const roomW = 100;
         const roomD = 80;
-        const roomH = 60;
+        const roomH = 90;
         const wallMaterial = MaterialsFactory.createWallMaterial();
 
         const floorGeometry = new THREE.PlaneGeometry(roomW, roomD);

--- a/src/lib/sim/pen-tablet.js
+++ b/src/lib/sim/pen-tablet.js
@@ -85,13 +85,18 @@ Object.assign(Pen3DSim.prototype, {
         const floorY = -29;
         const roomW = 100;
         const roomD = 80;
+        // Grow depth 50% toward the camera (+Z); keep the back wall fixed
+        const roomDExtra = roomD * 0.5;
+        const roomDFull = roomD + roomDExtra;
+        const roomCenterZ = deskZ + roomDExtra / 2;
+        const wallZBack = deskZ - roomD / 2;
         const roomH = 90;
         const wallMaterial = MaterialsFactory.createWallMaterial();
 
-        const floorGeometry = new THREE.PlaneGeometry(roomW, roomD);
+        const floorGeometry = new THREE.PlaneGeometry(roomW, roomDFull);
         const floor = new THREE.Mesh(floorGeometry, MaterialsFactory.createFloorMaterial());
         floor.rotation.x = -Math.PI / 2;
-        floor.position.set(0, floorY, deskZ);
+        floor.position.set(0, floorY, roomCenterZ);
         floor.receiveShadow = true;
         this.scene.add(floor);
 
@@ -100,27 +105,27 @@ Object.assign(Pen3DSim.prototype, {
             new THREE.PlaneGeometry(roomW, roomH),
             wallMaterial
         );
-        backWall.position.set(0, floorY + roomH / 2, deskZ - roomD / 2);
+        backWall.position.set(0, floorY + roomH / 2, wallZBack);
         backWall.receiveShadow = true;
         this.scene.add(backWall);
 
         // Left wall
         const leftWall = new THREE.Mesh(
-            new THREE.PlaneGeometry(roomD, roomH),
+            new THREE.PlaneGeometry(roomDFull, roomH),
             wallMaterial.clone()
         );
         leftWall.rotation.y = Math.PI / 2;
-        leftWall.position.set(-roomW / 2, floorY + roomH / 2, deskZ);
+        leftWall.position.set(-roomW / 2, floorY + roomH / 2, roomCenterZ);
         leftWall.receiveShadow = true;
         this.scene.add(leftWall);
 
         // Right wall
         const rightWall = new THREE.Mesh(
-            new THREE.PlaneGeometry(roomD, roomH),
+            new THREE.PlaneGeometry(roomDFull, roomH),
             wallMaterial.clone()
         );
         rightWall.rotation.y = -Math.PI / 2;
-        rightWall.position.set(roomW / 2, floorY + roomH / 2, deskZ);
+        rightWall.position.set(roomW / 2, floorY + roomH / 2, roomCenterZ);
         rightWall.receiveShadow = true;
         this.scene.add(rightWall);
 
@@ -129,7 +134,6 @@ Object.assign(Pen3DSim.prototype, {
         const boardDepth = 0.75;
         const boardMaterial = MaterialsFactory.createBaseboardMaterial();
         const boardY = floorY + boardH / 2;
-        const wallZBack = deskZ - roomD / 2;
         const wallXLeft = -roomW / 2;
         const wallXRight = roomW / 2;
 
@@ -142,18 +146,18 @@ Object.assign(Pen3DSim.prototype, {
         this.scene.add(backBoard);
 
         const leftBoard = new THREE.Mesh(
-            new THREE.BoxGeometry(boardDepth, boardH, roomD),
+            new THREE.BoxGeometry(boardDepth, boardH, roomDFull),
             boardMaterial.clone()
         );
-        leftBoard.position.set(wallXLeft + boardDepth / 2, boardY, deskZ);
+        leftBoard.position.set(wallXLeft + boardDepth / 2, boardY, roomCenterZ);
         leftBoard.receiveShadow = true;
         this.scene.add(leftBoard);
 
         const rightBoard = new THREE.Mesh(
-            new THREE.BoxGeometry(boardDepth, boardH, roomD),
+            new THREE.BoxGeometry(boardDepth, boardH, roomDFull),
             boardMaterial.clone()
         );
-        rightBoard.position.set(wallXRight - boardDepth / 2, boardY, deskZ);
+        rightBoard.position.set(wallXRight - boardDepth / 2, boardY, roomCenterZ);
         rightBoard.receiveShadow = true;
         this.scene.add(rightBoard);
 

--- a/src/lib/sim/pen-tablet.js
+++ b/src/lib/sim/pen-tablet.js
@@ -124,6 +124,39 @@ Object.assign(Pen3DSim.prototype, {
         rightWall.receiveShadow = true;
         this.scene.add(rightWall);
 
+        // Lighter baseboards along each wall
+        const boardH = 5;
+        const boardDepth = 0.75;
+        const boardMaterial = MaterialsFactory.createBaseboardMaterial();
+        const boardY = floorY + boardH / 2;
+        const wallZBack = deskZ - roomD / 2;
+        const wallXLeft = -roomW / 2;
+        const wallXRight = roomW / 2;
+
+        const backBoard = new THREE.Mesh(
+            new THREE.BoxGeometry(roomW, boardH, boardDepth),
+            boardMaterial
+        );
+        backBoard.position.set(0, boardY, wallZBack + boardDepth / 2);
+        backBoard.receiveShadow = true;
+        this.scene.add(backBoard);
+
+        const leftBoard = new THREE.Mesh(
+            new THREE.BoxGeometry(boardDepth, boardH, roomD),
+            boardMaterial.clone()
+        );
+        leftBoard.position.set(wallXLeft + boardDepth / 2, boardY, deskZ);
+        leftBoard.receiveShadow = true;
+        this.scene.add(leftBoard);
+
+        const rightBoard = new THREE.Mesh(
+            new THREE.BoxGeometry(boardDepth, boardH, roomD),
+            boardMaterial.clone()
+        );
+        rightBoard.position.set(wallXRight - boardDepth / 2, boardY, deskZ);
+        rightBoard.receiveShadow = true;
+        this.scene.add(rightBoard);
+
         // ── Pen display mode: embedded screen on tablet surface ──────────────
         const tabletScreenMaterial = MaterialsFactory.createMonitorScreenMaterial(
             TexturesFactory.createDesktopTexture()

--- a/src/lib/sim/pen-tablet.js
+++ b/src/lib/sim/pen-tablet.js
@@ -76,7 +76,10 @@ Object.assign(Pen3DSim.prototype, {
         }
 
         this.digitizerGrid = gridGroup;
+        this.gridMaterial = gridMaterial;
         this.scene.add(gridGroup);
+        this.darkTablet = false;
+        this.tabletCheckerboardVisible = false;
 
         // Floor + studio walls (no dark GridHelper)
         const floorY = -29;

--- a/src/lib/sim/pen-tablet.js
+++ b/src/lib/sim/pen-tablet.js
@@ -2,9 +2,9 @@ import * as THREE from 'three';
 import { MaterialsFactory } from './materials.js';
 import { TexturesFactory } from './textures.js';
 import { Pen3DSim } from './Pen3DSim.js';
-import { TABLET } from './config.js';
+import { TABLET, SCENE } from './config.js';
 
-// pen-tablet.js — Tablet mesh, grid, and checkerboard
+// pen-tablet.js — Tablet mesh, grid, desk, studio room
 // Extends Pen3DSim.prototype (must be loaded after Pen3DSim.js)
 
 Object.assign(Pen3DSim.prototype, {
@@ -19,21 +19,22 @@ Object.assign(Pen3DSim.prototype, {
         this.scene.add(tablet);
 
         const deskHeight = 1;
-        const deskGeometry = new THREE.BoxGeometry(60, deskHeight, 30);
-        const deskMesh = new THREE.Mesh(deskGeometry, MaterialsFactory.createDeskMaterial());
-        deskMesh.position.set(0, -deskHeight / 2, -6.5);
+        const deskW = 60, deskD = 30, deskZ = -6.5;
+        const woodMap = TexturesFactory.createWoodGrainTexture();
+        const deskGeometry = new THREE.BoxGeometry(deskW, deskHeight, deskD);
+        const deskMesh = new THREE.Mesh(deskGeometry, MaterialsFactory.createDeskMaterial(woodMap));
+        deskMesh.position.set(0, -deskHeight / 2, deskZ);
         deskMesh.receiveShadow = true;
         deskMesh.castShadow = true;
         this.scene.add(deskMesh);
 
-        // Desk legs
+        // Desk legs — solid light wood (no grain)
         const legHeight = 28;
         const legSize = 1.5;
         const legGeometry = new THREE.BoxGeometry(legSize, legHeight, legSize);
-        const legMaterial = MaterialsFactory.createDeskMaterial();
-        const deskW = 60, deskD = 30, deskZ = -6.5;
+        const legMaterial = MaterialsFactory.createDeskLegMaterial();
         const legY = -deskHeight - legHeight / 2;
-        const legInset = 2; // inset from desk edges
+        const legInset = 2;
         const legPositions = [
             [-deskW / 2 + legInset, legY, deskZ - deskD / 2 + legInset],
             [ deskW / 2 - legInset, legY, deskZ - deskD / 2 + legInset],
@@ -51,7 +52,7 @@ Object.assign(Pen3DSim.prototype, {
         // Store references for checkerboard pattern toggle
         this.tabletMesh = tablet;
         this.tabletMaterial = material;
-        this.tabletBaseColor = 0x505050;
+        this.tabletBaseColor = SCENE.tabletBase;
         this.tabletCheckerboardTexture = null;
 
         const gridGroup = new THREE.Group();
@@ -77,32 +78,59 @@ Object.assign(Pen3DSim.prototype, {
         this.digitizerGrid = gridGroup;
         this.scene.add(gridGroup);
 
-        const gridHelper = new THREE.GridHelper(50, 50, 0x444444, 0x222222);
-        // Floor
-        const floorGeometry = new THREE.PlaneGeometry(200, 200);
-        const floorMaterial = new THREE.MeshStandardMaterial({ color: 0x3a3a3a, roughness: 0.9, metalness: 0.0 });
-        const floor = new THREE.Mesh(floorGeometry, floorMaterial);
+        // Floor + studio walls (no dark GridHelper)
+        const floorY = -29;
+        const roomW = 100;
+        const roomD = 80;
+        const roomH = 60;
+        const wallMaterial = MaterialsFactory.createWallMaterial();
+
+        const floorGeometry = new THREE.PlaneGeometry(roomW, roomD);
+        const floor = new THREE.Mesh(floorGeometry, MaterialsFactory.createFloorMaterial());
         floor.rotation.x = -Math.PI / 2;
-        floor.position.y = -29;
+        floor.position.set(0, floorY, deskZ);
         floor.receiveShadow = true;
         this.scene.add(floor);
 
-        gridHelper.position.y = -29; // bottom of desk legs
-        this.scene.add(gridHelper);
+        // Back wall (behind monitor)
+        const backWall = new THREE.Mesh(
+            new THREE.PlaneGeometry(roomW, roomH),
+            wallMaterial
+        );
+        backWall.position.set(0, floorY + roomH / 2, deskZ - roomD / 2);
+        backWall.receiveShadow = true;
+        this.scene.add(backWall);
+
+        // Left wall
+        const leftWall = new THREE.Mesh(
+            new THREE.PlaneGeometry(roomD, roomH),
+            wallMaterial.clone()
+        );
+        leftWall.rotation.y = Math.PI / 2;
+        leftWall.position.set(-roomW / 2, floorY + roomH / 2, deskZ);
+        leftWall.receiveShadow = true;
+        this.scene.add(leftWall);
+
+        // Right wall
+        const rightWall = new THREE.Mesh(
+            new THREE.PlaneGeometry(roomD, roomH),
+            wallMaterial.clone()
+        );
+        rightWall.rotation.y = -Math.PI / 2;
+        rightWall.position.set(roomW / 2, floorY + roomH / 2, deskZ);
+        rightWall.receiveShadow = true;
+        this.scene.add(rightWall);
 
         // ── Pen display mode: embedded screen on tablet surface ──────────────
         const tabletScreenMaterial = MaterialsFactory.createMonitorScreenMaterial(
             TexturesFactory.createDesktopTexture()
         );
-        // Push the screen back in the depth buffer so the grid and cursor draw on top
         const tabletScreenGeometry = new THREE.PlaneGeometry(this.tabletWidth, this.tabletDepth);
         this.tabletScreen = new THREE.Mesh(tabletScreenGeometry, tabletScreenMaterial);
-        // Rotate to lie flat on the tablet surface (PlaneGeometry faces +Y after -90° X rotation)
         this.tabletScreen.rotation.x = -Math.PI / 2;
-        this.tabletScreen.position.y = this.yOffset + 0.005; // just above tablet surface
-        this.tabletScreen.visible = false; // hidden by default (pen tablet mode)
+        this.tabletScreen.position.y = this.yOffset + 0.005;
+        this.tabletScreen.visible = false;
         this.scene.add(this.tabletScreen);
-
     },
 
 });

--- a/src/lib/sim/textures.js
+++ b/src/lib/sim/textures.js
@@ -31,7 +31,7 @@ export class TexturesFactory {
     }
 
     // Create a checkerboard texture for the tablet
-    static createTabletCheckerboardTexture(tabletWidth, tabletDepth) {
+    static createTabletCheckerboardTexture(tabletWidth, tabletDepth, color1 = '#e4d8f0', color2 = '#c8b4dc') {
         // Grid spacing is 0.25 inches, tablet is 16x9 inches
         // So we need 64x36 squares
         const gridSpacing = 0.25;
@@ -49,9 +49,8 @@ export class TexturesFactory {
         const squareSizeX = canvas.width / squaresX;
         const squareSizeZ = canvas.height / squaresZ;
 
-        // Soft pink checkerboard for measuring on a pale pink tablet
-        const checkColor1 = '#f8e4e7';
-        const checkColor2 = '#e8c4cb';
+        const checkColor1 = color1;
+        const checkColor2 = color2;
 
         for (let z = 0; z < squaresZ; z++) {
             for (let x = 0; x < squaresX; x++) {

--- a/src/lib/sim/textures.js
+++ b/src/lib/sim/textures.js
@@ -49,9 +49,9 @@ export class TexturesFactory {
         const squareSizeX = canvas.width / squaresX;
         const squareSizeZ = canvas.height / squaresZ;
 
-        // Use brighter colors for better visibility
-        const checkColor1 = '#505050'; // Medium gray
-        const checkColor2 = '#404040'; // Light gray
+        // Soft pink checkerboard for measuring on a pale pink tablet
+        const checkColor1 = '#f8e4e7';
+        const checkColor2 = '#e8c4cb';
 
         for (let z = 0; z < squaresZ; z++) {
             for (let x = 0; x < squaresX; x++) {
@@ -89,6 +89,52 @@ export class TexturesFactory {
         ctx.fillRect(0, H - taskbarH, W, taskbarH);
 
         return new THREE.CanvasTexture(canvas);
+    }
+
+    /**
+     * Subtle procedural wood grain for the desk top (light maple).
+     * Grain runs along the desk depth (V) so strips read as planks from above.
+     */
+    static createWoodGrainTexture() {
+        const W = 512, H = 512;
+        const canvas = document.createElement('canvas');
+        canvas.width = W;
+        canvas.height = H;
+        const ctx = canvas.getContext('2d');
+
+        ctx.fillStyle = '#d4b896';
+        ctx.fillRect(0, 0, W, H);
+
+        for (let i = 0; i < 48; i++) {
+            const x = (i / 48) * W + (Math.sin(i * 1.7) * 3);
+            const alpha = 0.04 + (i % 5) * 0.012;
+            ctx.strokeStyle = `rgba(160, 120, 70, ${alpha})`;
+            ctx.lineWidth = 1 + (i % 3) * 0.5;
+            ctx.beginPath();
+            ctx.moveTo(x, 0);
+            for (let y = 0; y <= H; y += 8) {
+                ctx.lineTo(x + Math.sin(y * 0.04 + i) * 2.5, y);
+            }
+            ctx.stroke();
+        }
+
+        // Soft plank separators
+        for (let p = 1; p < 6; p++) {
+            const y = (p / 6) * H;
+            ctx.strokeStyle = 'rgba(140, 105, 60, 0.08)';
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            ctx.moveTo(0, y);
+            ctx.lineTo(W, y);
+            ctx.stroke();
+        }
+
+        const texture = new THREE.CanvasTexture(canvas);
+        texture.colorSpace = THREE.SRGBColorSpace;
+        texture.wrapS = THREE.RepeatWrapping;
+        texture.wrapT = THREE.RepeatWrapping;
+        texture.repeat.set(4, 2);
+        return texture;
     }
 
     // Create a text label texture for axis markers


### PR DESCRIPTION
## Summary
- Brighten the 3D studio with a light wood desk, white walls, warmer lighting, and a pale floor
- Restyle the tablet as a soft lavender matte slab with optional dark mode and clearer digitizer grid contrast
- Raise walls, add light baseboards, darken the floor slightly, and extend room depth toward the camera; sharpen pen shadows (GTAO tried then removed due to artifacts)

## Test plan
- [ ] Load the sim and confirm the studio reads bright (desk, walls, floor, lighting)
- [ ] Toggle Dark tablet and Checkerboard; verify grid/tablet colors update correctly
- [ ] Orbit around the room: taller walls, baseboards, longer floor toward camera
- [ ] Confirm pen and desk shadows look correct (no AO artifacts)
- [ ] Spot-check teaching overlays (annotations, cursor) remain readable on the bright backdrop
